### PR TITLE
CR-1371 DataTable column.filters fix

### DIFF
--- a/src/components/generic/DataTable/index.js
+++ b/src/components/generic/DataTable/index.js
@@ -262,7 +262,7 @@ class DataTable extends React.Component {
 
       // if a filter has been set via props, prevent user from changing it
       if (propFilters && propFilters[column.dataIndex]) {
-        column.filters = null
+        column.filters = []
       }
 
       if (column.remoteFilter) {


### PR DESCRIPTION
As per ANTD 3x docs, filters prop on column must be an array or not specified.

Source file from antd > Table > filterDropdown.js > function hasMenu() already sets column filters to empty array if undefined.

Null is not acceptable.